### PR TITLE
feature/compiler - Fix bug - several compiler options in one string

### DIFF
--- a/compiler/src/bin/compiler_main.rs
+++ b/compiler/src/bin/compiler_main.rs
@@ -19,7 +19,7 @@ fn main() -> std::io::Result<()> {
         compiler_type: CompilerType::Cpp,
         source_code_file_path: PathBuf::from("./temp/src/test.cpp"),
         compiled_directory_path: PathBuf::from("./temp/bin/"), 
-        compiler_options: String::from("-g"),
+        compiler_options: String::from("-g --std=c++17 -Wall"),
         //compiler_options: String::new(),
     };
 

--- a/compiler/src/compilers/cpp_compiler.rs
+++ b/compiler/src/compilers/cpp_compiler.rs
@@ -44,7 +44,11 @@ impl Compiler for CppCompiler {
         let mut compiler_command = Command::new("g++");
 
         if input_data.compiler_options != "" {
-            compiler_command.arg(&input_data.compiler_options);
+            for option in input_data.compiler_options.split(' ')
+            {
+                compiler_command.arg(option);
+                output_data.stdout.push_str(&format!("Compiler option added: {}\n", option));
+            }
         }
 
         compiler_command.arg(output_binary_argument);


### PR DESCRIPTION
Add splitting compiler options string by spaces - to get separate options in each argument