### PR TITLE
Fix #68. Add fd_divertion mod, that replaces shh's functionality.

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -26,7 +26,6 @@ path = "test/test.rs"
 sharedlib = "7.0.0"
 libc = "0.2.1"
 seccompiler = {version = "0.2.0", features=["json"] }
-shh = "1.0.1"
 fork = "0.1.18"
 nix = "0.23.0"
 slog = { version = "2.7.0", features = ["max_level_trace"] }
@@ -39,4 +38,3 @@ serde_yaml = "0.8.12"
 
 [dependencies.compiler]
 path = "../compiler"
-

--- a/runner/lib/data/output.rs
+++ b/runner/lib/data/output.rs
@@ -1,3 +1,13 @@
+/// Struct to hold results of running user code
+/// 
+/// Fields:
+/// * `stdout` both stdout and stderr of runned code
+/// * `stderr` error messages, that descripe what went wrong
+/// * `exit_code` process's exit exit
+/// 
+/// Stdout and Stderr are both redirected into `stdout`, so it may
+/// lead to some confusion, naming convention is temporary and has to be
+/// changed in the future
 #[derive(Default)]
 #[derive(Debug)]
 pub struct OutputData {

--- a/runner/lib/fd_divertion/fd_divertion.rs
+++ b/runner/lib/fd_divertion/fd_divertion.rs
@@ -1,0 +1,148 @@
+use std::fs::File;
+use std::io;
+use std::io::{Read, Error};
+use std::io::{Stdout, Stderr};
+use std::os::unix::prelude::{FromRawFd, RawFd, AsRawFd};
+
+/// Silence and redirect output from stdout and stderr
+/// into pipe
+/// `Devertion` implements io::Read
+/// # Example
+/// ```rust
+/// crate::fd_divertion::fd_divertion::Divertion;
+/// use std::str;
+/// 
+/// let mut div = Divertion::new().unwrap();
+/// div.divert();
+/// println!("print after divert");
+/// let mut buf: Vec<u8> = Vec::new();
+/// div.read_to_end(&mut buf).unwrap();
+/// drop (div);
+/// println!("what comes from pipe: {}", str::from_utf8(&buf).unwrap());
+/// ```
+pub(crate) struct Divertion
+{
+    original_out: i32,
+    original_err: i32,
+    read_file: File,
+    write_file: File,
+}
+
+impl Divertion
+{
+    pub fn new() -> Result<Self, Error>
+    {
+        let original_out = match unsafe { libc::dup(libc::STDOUT_FILENO)}
+        {
+            -1 => return Err(Error::last_os_error()),
+            fd => fd,
+        };
+        let original_err = match unsafe {libc::dup(libc::STDERR_FILENO)}
+        {
+            -1 => return Err(Error::last_os_error()),
+            fd => fd,
+        };
+        let (read_file, write_file) = Self::get_pipe()?;
+        Ok
+        (
+            Self 
+            {
+                original_out,
+                original_err,
+                read_file,
+                write_file
+            }
+        )
+    }
+
+    fn get_pipe() -> Result<(File, File), Error>
+    {
+        let mut outputs = [0;2];
+        if unsafe { libc::pipe(outputs.as_mut_ptr())} == -1 
+        {
+            return Err(Error::last_os_error())
+        }
+        let read_file = unsafe { FromRawFd::from_raw_fd(outputs[0])};
+        let write_file = unsafe { FromRawFd::from_raw_fd(outputs[1])};
+        Ok((read_file, write_file))
+    }
+
+    pub fn divert(&self) -> Result<(), Error>
+    {
+        if -1 == unsafe { libc::dup2(self.write_file.as_raw_fd(), libc::STDOUT_FILENO) } {
+            return Err(Error::last_os_error());
+        };
+        if -1 == unsafe { libc::dup2(self.write_file.as_raw_fd(), libc::STDERR_FILENO) } {
+            return Err(Error::last_os_error());
+        };
+
+        Ok(())
+    }
+
+    pub fn to_string(mut self) -> String 
+    {
+        let mut output = String::new();
+        self.read_to_string(&mut output);
+
+        output
+    }
+
+    fn _read(&mut self, buf: &mut [u8]) -> Result<usize, Error>
+    {
+        let mut avail = 0;
+        let res = unsafe {libc::ioctl(self.read_file.as_raw_fd(), libc::FIONREAD, &mut avail)};
+        if res == -1 
+        {
+            return Err(Error::last_os_error());
+        } 
+        else if avail == 0
+        {
+            Ok(0)
+        } 
+        else 
+        {
+            self.read_file.read(buf)
+        }
+    }
+}
+
+
+impl Drop for Divertion
+{
+    fn drop(&mut self) {
+        unsafe { 
+            libc::dup2(self.original_out, libc::STDOUT_FILENO);
+            libc::dup2(self.original_err, libc::STDERR_FILENO);
+            libc::close(self.original_out);
+            libc::close(self.original_err);
+        }
+
+    }
+}
+
+impl Read for Divertion
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error>
+    {
+        self._read(buf)
+    }
+}
+
+mod tests
+{
+    use super::Divertion;
+    use std::io::Read;
+    use std::str;
+
+    #[test]
+    fn test_read()
+    {
+        let mut div = Divertion::new().unwrap();
+        div.divert();
+        println!("print after divert");
+        let mut buf: Vec<u8> = Vec::new();
+        div.read_to_end(&mut buf).unwrap();
+        drop (div);
+        println!("what comes from pipe: {}", str::from_utf8(&buf).unwrap());
+    }
+}

--- a/runner/lib/fd_divertion/mod.rs
+++ b/runner/lib/fd_divertion/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod fd_divertion;

--- a/runner/lib/lib.rs
+++ b/runner/lib/lib.rs
@@ -1,5 +1,6 @@
 #![feature(thread_is_running)]
 pub mod data;
+mod fd_divertion;
 mod filter;
 mod config;
 mod runner;

--- a/runner/lib/runner/cpp_runner.rs
+++ b/runner/lib/runner/cpp_runner.rs
@@ -4,9 +4,9 @@ use super::Runner;
 use super::super::config::Config;
 use crate::data::output::OutputData;
 use crate::data::error::Error;
+use crate::fd_divertion::fd_divertion::Divertion;
 use super::lib_wrapper::LibWrapper as Lib;
 use seccompiler::{apply_filter};
-use shh;
 use slog::{Logger, trace, debug};
 use sharedlib:: {Symbol};
 use std::io::Read;
@@ -38,6 +38,9 @@ impl<'time> CppRunner<'time>
 
 impl<'time> Runner<'time> for CppRunner<'time> 
 {
+    /// Run shared object file compiled
+    /// * Shared object itself has to be compiled with
+    /// -shared -fpic options
     fn run(&self) -> Result<OutputData, Error> 
     {
         let bpf_prg = build_filter(self.logger)?;
@@ -50,24 +53,22 @@ impl<'time> Runner<'time> for CppRunner<'time>
             self.config.entry_point.clone()
         )?;
         let shared_func = lib.shared_func()?;
-        let mut shh_output = shh::stdout()?;
+        let mut divertion = Divertion::new()?;
 
         match unsafe {fork() } 
         {
             Ok(ForkResult::Parent{child}) => 
             {
                 let (exit_code , err_msg)= self.join_child(child)?;
-                let mut buf: Vec<u8> = Vec::new();
-                shh_output.read_to_end(&mut buf)?;
-                let stdout = str::from_utf8(&buf)?;
-                drop(shh_output);
-                let output_data = OutputData::new(stdout, &err_msg, exit_code);
+                let stdout = divertion.to_string();
+                let output_data = OutputData::new(stdout.as_str(), &err_msg, exit_code);
                 debug!(self.logger, "output_data: {:?}", output_data);
  
                 return Ok(output_data);
             }
             Ok(ForkResult::Child) => 
             {
+                divertion.divert()?;
                 let exit_code = match apply_filter(&bpf_prg) {
                     Ok(_) => 
                     {

--- a/runner/test/rust/makefile
+++ b/runner/test/rust/makefile
@@ -1,0 +1,19 @@
+CXX       := rustc
+CXX_FLAGS :=
+
+LIB     := lib
+SRC     := src
+INCLUDE := src
+
+# LIBRARIES   :=
+EXECUTABLE  := main
+
+
+all: 
+	@ for f in $(shell ls *.rs); do $(CXX) $(CXX_FLAGS) $^ -o ../$(LIB)/$${f%.*} $${f}; done;
+
+run: clean all
+	clear
+
+clean:
+	rm -rf $(BIN)/*

--- a/runner/test/rust/printtext.rs
+++ b/runner/test/rust/printtext.rs
@@ -1,0 +1,4 @@
+fn main() 
+{
+    println!("Message from shared object. Compiled with rustc.");
+}

--- a/runner/test/test.rs
+++ b/runner/test/test.rs
@@ -49,11 +49,11 @@ mod tests {
     #[test]
     fn prints_text() {
         let root = get_logger();
-        let path = PathBuf::from("test/lib/simple_print.so");
+        let path = PathBuf::from("test/lib/simple");
         let output= run_code(CPP, path, &root).unwrap();
         
         assert_eq!("", output.stderr);
-        assert_eq!("HI from cout\nAgain from cout\nHI from cerr\n", output.stdout);
+        assert_eq!("HI from cout\nHI from cerr\nAgain from cout\n", output.stdout);
         
     }
 
@@ -82,9 +82,6 @@ mod tests {
             Err(err) => println!("{:?}", err),
             Ok(_) => {}
         }
-        //handle.join().unwrap();
-        //thread::sleep(Duration::new(2, 0));
-        //panic!("shared function runs too long");
     }
 
     #[test]


### PR DESCRIPTION
Delete shh from Cargo.toml, now use custom Divertion.